### PR TITLE
Allow reverse lookup of objects that depend on a given named object

### DIFF
--- a/dist/jector.js
+++ b/dist/jector.js
@@ -7,6 +7,7 @@
       this.pending = {};
       this.singletons = {};
       this.factories = {};
+      this.dependees = {};
     }
 
     Context.prototype.factory = function(name, fn) {
@@ -47,6 +48,7 @@
       return argNames.map((function(_this) {
         return function(argName) {
           var instance;
+          _this._dependsOn(argName, name);
           if ((instance = _this._get(argName, depChain)) != null) {
             return instance;
           } else {
@@ -54,6 +56,13 @@
           }
         };
       })(this));
+    };
+
+    Context.prototype._dependsOn = function(dependee, dependant) {
+      if (this.dependees[dependee] == null) {
+        this.dependees[dependee] = {};
+      }
+      return this.dependees[dependee][dependant] = true;
     };
 
     Context.prototype.singleton = function(name, type) {
@@ -113,6 +122,23 @@
         return processor(depChain);
       }
       return this.singletons[name];
+    };
+
+    Context.prototype.dependants = function(name) {
+      var key, processor, value;
+      if ((processor = this.pending[name]) != null) {
+        processor();
+      }
+      return (function() {
+        var _ref, _results;
+        _ref = this.dependees[name];
+        _results = [];
+        for (key in _ref) {
+          value = _ref[key];
+          _results.push(key);
+        }
+        return _results;
+      }).call(this);
     };
 
     return Context;

--- a/spec/Context.spec.coffee
+++ b/spec/Context.spec.coffee
@@ -233,6 +233,27 @@ describe 'Context', ->
       context.value('rock', rock)
       expect(context.get('rock')).toBe(rock)
 
+  describe 'dependants', ->
+
+    it 'returns the list of dependency names for the named instance', ->
+      context.value('slab', Slab)
+      context.singleton('frame', Frame)
+      context.factory('truss', Truss)
+      context.factory('roof', Roof)()
+
+      expect(context.dependants('roof')).toEqual([])
+      expect(context.dependants('truss')).toContain('roof')
+      expect(context.dependants('frame')).toContain('roof', 'truss')
+      expect(context.dependants('slab')).toContain('roof', 'frame', 'truss')
+
+    it 'is empty if the named dependency does not exist', ->
+      expect(context.dependants('bogus')).toEqual([])
+
+    it 'is empty if the named dependency has not been instantiated', ->
+      context.singleton('slab', Slab)
+      context.singleton('frame', Frame)
+      expect(context.dependants('frame')).toEqual([])
+
 
 class Slab
   constructor: () ->


### PR DESCRIPTION
Incremental change to potentially allow replacement of a named dependency at runtime. (This might be useful for some testing scenarios, for example.)
